### PR TITLE
WDP220801-49 (Bug rozwijane menu #2)

### DIFF
--- a/src/components/layout/MenuBar/MenuBar.module.scss
+++ b/src/components/layout/MenuBar/MenuBar.module.scss
@@ -22,7 +22,6 @@
         display: flex;
         align-items: stretch;
 
-        
         .menuLink {
           color: $text-color;
           text-transform: uppercase;
@@ -47,7 +46,6 @@
             border-color: $text-color;
           }
         }
-
       }
     }
   }
@@ -59,6 +57,7 @@
     .collapse_list {
       display: none;
       position: absolute;
+      z-index: 2;
 
       ul {
         margin: 0;


### PR DESCRIPTION
Do elementu listy w rozwijanym menu dodałem właściwość z-index o wartości wyższej niż overlay w komponencie Promoted.