### PR TITLE
Add RWD to Promoted

### DIFF
--- a/src/components/features/Promoted/Promoted.js
+++ b/src/components/features/Promoted/Promoted.js
@@ -16,7 +16,8 @@ import {
 import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons';
 import { useDispatch } from 'react-redux';
 import { toggleProductFavorite } from '../../../redux/productsRedux';
-
+import { getView } from '../../../redux/viewRedux';
+import Swipeable from '../../common/Swipeable/Swipeable';
 const Promoted = () => {
   const products = useSelector(state => getAll(state));
   console.log('products', products[1].name);
@@ -27,12 +28,18 @@ const Promoted = () => {
     e.preventDefault();
     dispatch(toggleProductFavorite(productId));
   };
-
+  const view = useSelector(state => getView(state));
+  const leftAction = () => {
+    console.log('Change slide to left');
+  };
+  const rightAction = () => {
+    console.log('Change slide to right');
+  };
   return (
     <div className={styles.root}>
       <div className='container'>
         <div className='row'>
-          <div className='col-4'>
+          <div className={clsx('col-4', view === 'mobile' && styles.hide)}>
             <div className={styles.leftColumn}>
               <div className={styles.headerLeftColumn}>
                 <h2>Hot deals</h2>
@@ -125,27 +132,29 @@ const Promoted = () => {
             </div>
           </div>
 
-          <div className='col-8'>
-            <div className={styles.rightColumn}>
-              <div className={styles.imageRightColumn}>
-                <img
-                  className={styles.imageRight}
-                  src={`${process.env.PUBLIC_URL}/images/products/Aenean Ru Bristique 18.jpg`}
-                  alt='Aenean Ru Bristique'
-                />
-                <div className={styles.hero}>
-                  <h1>
-                    Indoor<span> Furniture</span>
-                  </h1>
-                  <h2>Save up to 50% of all furniture</h2>
-                  <button className={styles.heroButton}>Shop now</button>
+          <div className='col'>
+            <Swipeable rightAction={rightAction} leftAction={leftAction}>
+              <div className={styles.rightColumn}>
+                <div className={styles.imageRightColumn}>
+                  <img
+                    className={styles.imageRight}
+                    src={`${process.env.PUBLIC_URL}/images/products/Aenean Ru Bristique 18.jpg`}
+                    alt='Aenean Ru Bristique'
+                  />
+                  <div className={styles.hero}>
+                    <h1>
+                      Indoor<span> Furniture</span>
+                    </h1>
+                    <h2>Save up to 50% of all furniture</h2>
+                    <button className={styles.heroButton}>Shop now</button>
+                  </div>
+                </div>
+                <div className={styles.imageArrows}>
+                  <button className={styles.arrowLeft}>&#60;</button>
+                  <button className={styles.arrowRight}>&#62;</button>
                 </div>
               </div>
-              <div className={styles.imageArrows}>
-                <button className={styles.arrowLeft}>&#60;</button>
-                <button className={styles.arrowRight}>&#62;</button>
-              </div>
-            </div>
+            </Swipeable>
           </div>
         </div>
       </div>

--- a/src/components/features/Promoted/Promoted.module.scss
+++ b/src/components/features/Promoted/Promoted.module.scss
@@ -278,3 +278,7 @@
     }
   }
 }
+//Responsive
+.hide {
+  display: none;
+}


### PR DESCRIPTION
Zadanie:
Zadaniem jest stworzenie wersji mobilnych sekcji "Promowane". Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
Na szerokościach mobile należy ukryć lewy slider ("Hot deals") i pokazywać tylko prawy, na całą szerokość containera.
Ma działać przesuwanie slajdów za pomocą komponentu Swipeable (jest na niego osobne zadanie – jeśli nie jest gotowe to trzeba przygotować funkcje, które będą wykonywane przy swipe w lewo i w prawo).

Rozwiązanie:
- szerokość ekranu pobrana ze stanu aplikacji
- ukrycie lewej kolumny przez display nowe na mobile
- założony swipeable z funkcjami left right (obecnie tylko z console.log, brak funkcjonalności slidera na obecnym etapie)